### PR TITLE
Add Github Actions for drafting a release, and publishing that release to modrinth.

### DIFF
--- a/.github/workflows/draft-release.yml
+++ b/.github/workflows/draft-release.yml
@@ -22,31 +22,25 @@ jobs:
         uses: actions/checkout@v4
         with:
           ref: 'main'
-          sparse-checkout: |
-            assets
-            pack.mcmeta
-            pack.png
 
       - name: Archive Resource Pack
         uses: thedoctor0/zip-release@0.7.5
         with:
           type: 'zip'
           filename: 'geofont-mc-${{ inputs.release_version }}.zip'
+          exclusions: '/.github README.md LICENSE.md images'
 
       - name: Checkout branch (edge)
         uses: actions/checkout@v4
         with:
           ref: 'edge'
-          sparse-checkout: |
-            assets
-            pack.mcmeta
-            pack.png
 
       - name: Archive Resource Pack
         uses: thedoctor0/zip-release@0.7.5
         with:
           type: 'zip'
           filename: 'geofont-edge-mc-${{ inputs.release_version }}.zip'
+          exclusions: 'README.md LICENSE.md images'
 
       - name: Draft Release
         uses: softprops/action-gh-release@v2

--- a/.github/workflows/draft-release.yml
+++ b/.github/workflows/draft-release.yml
@@ -1,0 +1,61 @@
+name: Draft Github Release
+
+on:
+  workflow_dispatch:
+    inputs:
+      release_version:
+        description: 'version for the release (used in tag, title, and resource pack file name)'
+        default: 'v2.x.x'
+        required: true
+        type: string
+      release_desc:
+        description: 'description for the release'
+        default: 'changes were made'
+        required: false
+        type: string
+
+jobs:
+  draft-release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout branch (main)
+        uses: actions/checkout@v4
+        with:
+          ref: 'main'
+          sparse-checkout: |
+            assets
+            pack.mcmeta
+            pack.png
+
+      - name: Archive Resource Pack
+        uses: thedoctor0/zip-release@0.7.5
+        with:
+          type: 'zip'
+          filename: 'geofont-mc-${{ inputs.release_version }}.zip'
+
+      - name: Checkout branch (edge)
+        uses: actions/checkout@v4
+        with:
+          ref: 'edge'
+          sparse-checkout: |
+            assets
+            pack.mcmeta
+            pack.png
+
+      - name: Archive Resource Pack
+        uses: thedoctor0/zip-release@0.7.5
+        with:
+          type: 'zip'
+          filename: 'geofont-edge-mc-${{ inputs.release_version }}.zip'
+
+      - name: Draft Release
+        uses: softprops/action-gh-release@v2
+        with:
+          draft: true
+          name: 'Geofont ${{ inputs.release_version }}'
+          body: ${{ inputs.release_desc }}
+          tag_name: ${{ inputs.release_version }}
+          make_latest: 'true'
+          files: |
+            geofont-mc-${{ inputs.release_version }}.zip
+            geofont-edge-mc-${{ inputs.release_version }}.zip

--- a/.github/workflows/draft-release.yml
+++ b/.github/workflows/draft-release.yml
@@ -23,7 +23,7 @@ jobs:
         with:
           ref: 'main'
 
-      - name: Archive Resource Pack
+      - name: Archive Resource Pack (main)
         uses: thedoctor0/zip-release@0.7.5
         with:
           type: 'zip'
@@ -35,7 +35,7 @@ jobs:
         with:
           ref: 'edge'
 
-      - name: Archive Resource Pack
+      - name: Archive Resource Pack (edge)
         uses: thedoctor0/zip-release@0.7.5
         with:
           type: 'zip'

--- a/.github/workflows/publish-modrinth.yml
+++ b/.github/workflows/publish-modrinth.yml
@@ -1,0 +1,66 @@
+name: Publish Latest Release to Modrinth
+
+on:
+  release:
+    types: [published]
+
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+jobs:
+  publish-modrinth:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Publish Geofont to Modrinth
+        uses: cloudnode-pro/modrinth-publish@v2
+        with:
+          token: ${{ secrets.MODRINTH_TOKEN }}
+          project: AABBCCDD
+          name: ${{ github.event.release.name }}
+          version: ${{ github.event.release.tag_name }}
+          changelog: ${{ github.event.release.body }}
+          loaders: minecraft
+          game-versions: |-
+            1.13.x
+            1.14.x
+            1.15.x
+            1.16.x
+            1.17.x
+            1.18.x
+            1.19.x
+            1.20.x
+            1.21.x
+          files: path/to/file.zip
+          # Adds Caxton as an optional dependency
+          dependencies: |-
+            [{
+                "project_id": 'k8iIgzXE',
+                "dependency_type": 'optional'
+            }]
+
+      - name: Publish Edge to Modrinth
+        uses: cloudnode-pro/modrinth-publish@v2
+        with:
+          token: ${{ secrets.MODRINTH_TOKEN }}
+          project: AABBCCDD
+          name: ${{ github.event.release.name }}
+          version: ${{ github.event.release.tag_name }}
+          changelog: ${{ github.event.release.body }}
+          loaders: minecraft
+          game-versions: |-
+            1.13.x
+            1.14.x
+            1.15.x
+            1.16.x
+            1.17.x
+            1.18.x
+            1.19.x
+            1.20.x
+            1.21.x
+          files: path/to/file.zip
+          # Adds Caxton as an optional dependency
+          dependencies: |-
+            [{
+                "project_id": 'k8iIgzXE',
+                "dependency_type": 'optional'
+            }]

--- a/.github/workflows/publish-modrinth.yml
+++ b/.github/workflows/publish-modrinth.yml
@@ -1,24 +1,27 @@
 name: Publish Latest Release to Modrinth
 
 on:
-  release:
-    types: [published]
-
-  # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 
 jobs:
   publish-modrinth:
     runs-on: ubuntu-latest
     steps:
+      - name: Download Packs from Release
+        uses: robinraju/release-downloader@v1
+        with:
+          latest: true
+          fileName: 'geofont-*'
+        
       - name: Publish Geofont to Modrinth
         uses: cloudnode-pro/modrinth-publish@v2
         with:
           token: ${{ secrets.MODRINTH_TOKEN }}
-          project: AABBCCDD
+          project: YNuo4qic
           name: ${{ github.event.release.name }}
           version: ${{ github.event.release.tag_name }}
           changelog: ${{ github.event.release.body }}
+          status: draft
           loaders: minecraft
           game-versions: |-
             1.13.x
@@ -30,7 +33,7 @@ jobs:
             1.19.x
             1.20.x
             1.21.x
-          files: path/to/file.zip
+          files: 'geofont-mc-${{ inputs.release_version }}.zip'
           # Adds Caxton as an optional dependency
           dependencies: |-
             [{
@@ -42,10 +45,11 @@ jobs:
         uses: cloudnode-pro/modrinth-publish@v2
         with:
           token: ${{ secrets.MODRINTH_TOKEN }}
-          project: AABBCCDD
+          project: 8rGGW5Iw
           name: ${{ github.event.release.name }}
           version: ${{ github.event.release.tag_name }}
           changelog: ${{ github.event.release.body }}
+          status: draft
           loaders: minecraft
           game-versions: |-
             1.13.x
@@ -57,7 +61,7 @@ jobs:
             1.19.x
             1.20.x
             1.21.x
-          files: path/to/file.zip
+          files: 'geofont-edge-mc-${{ inputs.release_version }}.zip'
           # Adds Caxton as an optional dependency
           dependencies: |-
             [{


### PR DESCRIPTION
This assumes that the new releases are not legacy, and both the main font and edge are being updated.
Both actions require manual activation, and will only make drafts.
A Modrinth PAT needs to be added to secrets under the name `MODRINTH_TOKEN` for this to work btw